### PR TITLE
Fix small typos in filter_map, get rid of into_iter() for range

### DIFF
--- a/README.md
+++ b/README.md
@@ -6856,7 +6856,7 @@ So just remember: if you need a value in a thread from outside the thread, you n
 You can make your own functions that take closures, but inside a function it is less free and you have to decide the type of closure. Outside a function a closure can decide by itself between `Fn`, `FnMut` and `FnOnce`, but inside you have to choose one. The best way to understand is to look at a few function signatures. Here is the one for `.all()`, which we know checks an iterator to see if everything is `true` (depending on what you decide is `true` or `false`). Part of its signature says this:
 
 ```rust
-    fn all<F>(&mut self, f: F) -> bool    // incomplete code snippet
+    fn all<F>(&mut self, f: F) -> bool    // (note: this will not compile) incomplete code snippet
     where
         F: FnMut(Self::Item) -> bool,
 ```
@@ -6870,7 +6870,7 @@ Next is the part about the closure: `F: FnMut(Self::Item) -> bool`. Here it deci
 Here is a much simpler signature with a closure:
 
 ```rust
-fn do_something<F>(f: F)    // incomplete code snippet
+fn do_something<F>(f: F)    // (note: this will not compile) incomplete code snippet
 where
     F: FnOnce(),
 {
@@ -7041,7 +7041,7 @@ fn main() {
 However, the more interesting part is that we can return `impl Trait`, and that lets us return closures because their function signatures are traits. You can see this in the signatures for methods that have them. For example, this is the signature for `.map()`:
 
 ```rust
-fn map<B, F>(self, f: F) -> Map<Self, F>     // incomplete snippet
+fn map<B, F>(self, f: F) -> Map<Self, F>     // (note: this will not compile) incomplete code snippet
     where
         Self: Sized,
         F: FnMut(Self::Item) -> B,

--- a/README.md
+++ b/README.md
@@ -4972,7 +4972,7 @@ This prints `["June", "July"]`.
 
 
 
-`.filter_map()`. This is called `filter_map()` because it does `.filter()` and `.map()`. The closure must return an `Option<T>`, and then `filter.map()` takes the value out of each `Option` if it is `Some`. So for example if you were to `.filter_map()` a `vec![Some(9), None, Some(3)]`, it would return `[2, 3]`.
+`.filter_map()`. This is called `filter_map()` because it does `.filter()` and `.map()`. The closure must return an `Option<T>`, and then `filter.map()` takes the value out of each `Option` if it is `Some`. So for example if you were to `.filter_map()` a `vec![Some(2), None, Some(3)]`, it would return `[2, 3]`.
 
 We will write an example with a `Company` struct. Each company has a `name` so that field is `String`, but the CEO might have recently quit. So the `ceo` field is `Some<String>`. We will `.filter_map()` over some companies to just keep the CEO names.
 
@@ -5256,7 +5256,7 @@ Some(5)
 Some(6)
 ```
 
-We were right: there is oone `Some(5)` and then the 1000 `Some(6)` start. So we can write this:
+We were right: there is one `Some(5)` and then the 1000 `Some(6)` start. So we can write this:
 
 ```rust
 fn main() {
@@ -5343,8 +5343,8 @@ Something similar can be done with a range that doesn't have an ending. If you w
 
 ```rust
 fn main() {
-    let ten_chars = ('a'..).into_iter().take(10).collect::<Vec<char>>();
-    let skip_then_ten_chars = ('a'..).into_iter().skip(1300).take(10).collect::<Vec<char>>();
+    let ten_chars = ('a'..).take(10).collect::<Vec<char>>();
+    let skip_then_ten_chars = ('a'..).skip(1300).take(10).collect::<Vec<char>>();
 
     println!("{:?}", ten_chars);
     println!("{:?}", skip_then_ten_chars);


### PR DESCRIPTION
No need for the into_iter(), range already implements the Iterator trait.

