### PR TITLE
This block describes the typing incorrectly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7101,7 +7101,7 @@ fn map<B, F>(self, f: F) -> Map<Self, F>     // (note: this will not compile) in
     }
 ```
 
-`fn map<B, F>(self, f: F)` mean that it takes two generic types. `B` is self and `F` is the closure. Then after the `where` we see the trait bounds. ("Trait bound" means "it must have this trait".) One is `Sized`, but the next is the closure signature. It must be an `FnMut`, and do the closure on `Self::Item`, which is the iterator that you give it. Then it returns `B`, which is self.
+`fn map<B, F>(self, f: F)` mean that it takes two generic types. `F` is a function that takes one item from the container implementing `.map()` and `B` is the return type of that function. Then after the `where` we see the trait bounds. ("Trait bound" means "it must have this trait".) One is `Sized`, but the next is the closure signature. It must be an `FnMut`, and do the closure on `Self::Item`, which is the iterator that you give it. Then it returns `B`.
 
 So we can do the same thing to return a closure. To return a closure, use `impl` and then the closure signature. Once you return it, you can use it just like a function. Here is a small example of a function that gives you a closure depending on the number you put in. If you put 2 or 40 in then it multiplies it, and otherwise it gives you the same number. Because it's a closure we can do anything we want, so we also print a message.
 


### PR DESCRIPTION
Consider the following demonstration (this code compiles under Rust 2018 as a drop in for the contents of main.rs after `cargo new mapdemo --bin`, edit `main.rs`, and then `cargo run`):

```
fn main() {
	let x = [1, 2, 3, 4, 5];
	let z = x.iter().map(|&x| format!("{}", x)).collect::<Vec<String>>();
	println!("{:?}", z);
}
```
This prints an array of strings:
```
["1", "2", "3", "4", "5"]
```

The `self` argument to map will be an `Iter<u64>`.  The `Self::Item` type is therefore `u64`.  The return type of the function being passed to map is `String`.  This is what the `B` type variable indicates: the return type of the function, as can be clearly seen in the second line of the `where` clause in your example:

```
    F: FnMut(Self::Item) -> B
```