### PR TITLE
Incorrect formatting of `print_one_thing` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -9020,7 +9020,7 @@ note: the function `prints_one_thing` is defined here
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ```
 
-`function `print_one_thing` is private is easy to understand. It also shows us where to find the function. This is because once you start using `mod` you might also be using more than one file as well, and it can be hard to find things.
+function `print_one_thing` is private is easy to understand. It also shows us where to find the function. This is because once you start using `mod` you might also be using more than one file as well, and it can be hard to find things.
 
 Now we just write `pub fn` instead of `fn` and everything works.
 


### PR DESCRIPTION
This caused the whole sentence to be highlighted instead the function name.

<img width="779" alt="Screenshot 2020-08-02 at 09 54 32" src="https://user-images.githubusercontent.com/6843074/89118444-2d6d0300-d4a6-11ea-89c2-2dc1ad6a2359.png">
