### PR TITLE
OsString: calling unwrap will panic, use match instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -10811,36 +10811,38 @@ You can do all the regular things with an `OsString` like `OsString::from("Write
 pub fn into_string(self) -> Result<String, OsString>
 ```
 
-So if it doesn't work then you just get it back. You can even `.unwrap()` and it won't panic - you'll just not get a `String`. Let's test it out by calling methods that don't exist.
+So if it doesn't work then you just get it back. You can't call `.unwrap()` as it will panic, but you can use `match` to get the `OsString` back. Let's test it out by calling methods that don't exist.
 
 ```rust
 use std::ffi::OsString;
 
 fn main() {
     // ⚠️
-    let an_os_string = OsString::from("This string works for your OS too.");
-    let new_string = an_os_string.into_string().unwrap();
-    an_os_string.thth(); // Compiler: "What's .thth()??"
-    new_string.occg();   // Compiler: "What's .occg()??"
+    let os_string = OsString::from("This string works for your OS too.");
+    match os_string.into_string() {
+        Ok(valid) => valid.thth(),           // Compiler: "What's .thth()??"
+        Err(not_valid) => not_valid.occg(),  // Compiler: "What's .occg()??"
+    }
 }
 ```
 
 Then the compiler tells us exactly what we want to know:
 
 ```text
-error[E0599]: no method named `thth` found for struct `std::ffi::OsString` in the current scope
- --> src\main.rs:6:18
+error[E0599]: no method named `thth` found for struct `std::string::String` in the current scope
+ --> src/main.rs:6:28
   |
-6 |     an_os_string.thth();
-  |                  ^^^^ method not found in `std::ffi::OsString`
+6 |         Ok(valid) => valid.thth(),
+  |                            ^^^^ method not found in `std::string::String`
 
-error[E0599]: no method named `occg` found for struct `std::string::String` in the current scope
- --> src\main.rs:7:16
+error[E0599]: no method named `occg` found for struct `std::ffi::OsString` in the current scope
+ --> src/main.rs:7:37
   |
-7 |     new_string.occg();
-  |                ^^^^ method not found in `std::string::String`
+7 |         Err(not_valid) => not_valid.occg(),
+  |                                     ^^^^ method not found in `std::ffi::OsString`
 ```
 
+We can see that the type of `valid` is `String` and the type of `not_valid` is `OsString`.
 
 # Part 2 - Rust on your computer
 


### PR DESCRIPTION
Calling `.unwrap()` on a `Result<String, OsString>` will panic if the value is `Err(OsString)`. Suggest using `match` instead.

The easiest way to test this is giving the program a command line argument that is not a valid UTF-8:

```
cargo run -q $(printf "\\x80")
```

This works:

```rust
fn main() {
    let os_string = std::env::args_os()
        .skip(1)
        .next()
        .expect("Need one command line argument");

    match os_string.into_string() {
        Ok(str) => println!("Valid UTF-8: {}", str),
        Err(os_str) => println!("Not valid UTF-8: {:?}", os_str),
    }
}
```
Output: `Not valid UTF-8: "\x80"`

This panics:

```rust
fn main() {
    let os_string = std::env::args_os()
        .skip(1)
        .next()
        .expect("Need one command line argument");

    let s = os_string.into_string().unwrap();
}
```

Output: ``thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: "\x80"', src/main.rs:7:13``

