### PR TITLE
Fix a couple of snippets; snippets-test - don't exit early.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ help: ## Print help for each target
 book: ## Generate an mdBook version
 	@./createBookFromReadme.sh
 
-snippets: ## Create snippets
+snippets: clean ## Create snippets
 	@type md2src >/dev/null 2>&1 || (echo "Run 'cargo install md2src' first." >&2 ; exit 1)
 	@mkdir -p $(SNIPPETS)
 	@md2src "README.md" "$(SNIPPETS)" -i "// ⚠️" -i "// 🚧" ## ignore snippets that contain these strings
@@ -31,7 +31,7 @@ snippets: ## Create snippets
 snippets-test: snippets ## Test snippets
 	@for snippet in $$(ls $(SNIPPETS)/*.rs); do \
 	    echo "File $$snippet:" ; \
-		rustc --out-dir "$(SNIPPETS)" $$snippet || exit 1; \
+		rustc --out-dir "$(SNIPPETS)" $$snippet; \
 	done
 
 feedback: ## Give feedback

--- a/README.md
+++ b/README.md
@@ -2299,7 +2299,7 @@ fn main() {
             _ => println!("That star is pretty big!"),
         }
     }
-    println!("What about DeadStar? It's the number {}.", DeadStar);
+    println!("What about DeadStar? It's the number {}.", DeadStar as u32);
 }
 ```
 
@@ -9927,7 +9927,6 @@ mod tests {
         math("7 + seven");
     }
 }
-
 ```
 
 Finally we add two new methods. One is called `.clear()` and clears the `current_input()`. The other one is called `push_char()` and pushes the input onto `current_input()`. Here is our refactored code:
@@ -10829,6 +10828,7 @@ So an `OsString` is made to be read by all of them.
 You can do all the regular things with an `OsString` like `OsString::from("Write something here")`. It also has an interesting method called `.into_string()` that tries to make it into a regular `String`. It returns a `Result`, but the `Err` part is just the original `OsString`:
 
 ```rust
+// 🚧
 pub fn into_string(self) -> Result<String, OsString>
 ```
 
@@ -10968,7 +10968,7 @@ fn main() {
     let mut capital_city = City {
         name: "Constantinople".to_string(),
     };
-    capital_of_turkey.change_name("Istanbul");
+    capital_city.change_name("Istanbul");
 }
 ```
 
@@ -10977,6 +10977,7 @@ This prints `The city once called Constantinople is now called Istanbul.`.
 One function called `.take()` is like `.replace()` but it leaves the default value in the item. You will remember that default values are usually things like 0, "", and so on. Here is the signature:
 
 ```rust
+// 🚧
 pub fn take<T>(dest: &mut T) -> T 
 where
     T: Default, 


### PR DESCRIPTION
Fix a couple of snippets.

Avoid early exit in `snippets-test`, allows us to see all errors, and chose to ignore some of them (missing main in tests, missing crates, etc...).