### PR TITLE
minor fix deref_and_derefmut

### DIFF
--- a/README.md
+++ b/README.md
@@ -10366,8 +10366,8 @@ fn main() {
 This prints:
 
 ```text
-40
 None
+40
 ```
 
 We can also implement `DerefMut` so we can change the values through `*`. It looks almost the same. You need `Deref` before you can implement `DerefMut`.


### PR DESCRIPTION
minor fix [here](https://github.com/Dhghomon/easy_rust#deref-and-derefmut)

code example: 
```
fn main() {
    let my_number = HoldsANumber(20);
    println!("{:?}", my_number.checked_sub(100)); // This method comes from u8 <- should print None
    my_number.prints_the_number_times_two(); // This is our own method  <- should print 40
}
```

but its written:
```

This prints:

40
None
```
a little ambiguous since `checked_sub` should return `Option` but instead it is `u8` . I thought there was `.unwrap()` missing then realized just result print ordering issue.


