### PR TITLE
Use mdbook as command in the script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ help: ## Print help for each target
 	@grep '^[[:alnum:]_-]*:.* ##' $(MAKEFILE_LIST) \
         | sort | awk 'BEGIN {FS=":.* ## "}; {printf "%-25s %s\n", $$1, $$2};'
 
-book: ## Generate an mdBook version
+book: ## Generate an mdBook version on your local and start serving in browser
 	@./createBookFromReadme.sh
 
-github_pages: ## Generate an mdBook version
+github_pages: ## Generate an mdBook version for the Github Pages
 	@./createGithubPagesFromReadme.sh
 
 snippets: clean ## Create snippets

--- a/createBookFromReadme.sh
+++ b/createBookFromReadme.sh
@@ -49,7 +49,7 @@ function createSummary(){
 # Note:
 #     Install mdBook as per instructions in their repo https://github.com/rust-lang/mdBook
 function buildAndServeBookLocally(){
-    mdBook build && mdBook serve --open
+    mdbook build && mdbook serve --open
 }
 
 # -------------------- Steps to create the mdBook version --------------------


### PR DESCRIPTION
The command would fail when because it was using `mdBook` instead of `mdbook` specifically when serving on local.

![Screenshot from 2021-01-04 17-03-19](https://user-images.githubusercontent.com/2096087/103554172-c6b5a080-4eae-11eb-87cf-a595305d757a.png)
