### PR TITLE
Correct definition of unsigned ints to include zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Rust has simple types that are called **primitive types** (primitive = very basi
 - Signed integers,
 - Unsigned integers.
 
-Signed means `+` (plus sign) and `-` (minus sign), so signed integers can be positive or negative (e.g. +8, -8). But unsigned integers can only be positive, because they do not have a sign.
+Signed means `+` (plus sign) and `-` (minus sign), so signed integers can be positive (e.g. +8), negative (e.g. -8), or zero. But unsigned integers can only be positive or zero, because they do not have a sign.
 
 The signed integers are: `i8`, `i16`, `i32`, `i64`, `i128`, and `isize`.
 The unsigned integers are: `u8`, `u16`, `u32`, `u64`, `u128`, and `usize`.


### PR DESCRIPTION
Zero is allowed, not only positive. Yes, this is nitpicking, but it's more technically correct now.