### PR TITLE
Fix github-pages workflow

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt install linuxbrew-wrapper


### PR DESCRIPTION
mdbook binary being used is a gnu target that depends on glibc version. But glibc version is not match on ubuntu 18.04 since mdbook v0.4.21 is building on ubuntu 20.04.